### PR TITLE
Add FastAPI app to deliver daily undervalued stocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# gem-stocks
+# Gem Stocks
+
+This project contains a simple FastAPI application that exposes a list of
+potentially undervalued stocks. The list is updated every day at 8 AM UTC using
+`APScheduler` and basic data from Yahoo Finance via `yfinance`.
+
+## Running the server
+
+Install dependencies and start the application with `uvicorn`:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Access the list at `http://localhost:8000/undervalued`.
+
+Note that fetching stock information requires network access.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from typing import List, Dict
+
+from .stocks import fetch_undervalued_stocks
+
+app = FastAPI()
+
+# cache for stocks
+data_cache: List[Dict[str, float]] = []
+
+def update_stocks() -> None:
+    global data_cache
+    tickers = [
+        "AAPL",
+        "MSFT",
+        "GOOG",
+        "AMZN",
+        "META",
+    ]
+    data_cache = fetch_undervalued_stocks(tickers)
+
+
+scheduler = BackgroundScheduler(timezone="UTC")
+scheduler.add_job(update_stocks, CronTrigger(hour=8, minute=0))
+scheduler.start()
+
+# run immediately on startup
+update_stocks()
+
+
+@app.get("/undervalued")
+def get_stocks() -> List[Dict[str, float]]:
+    return data_cache

--- a/app/stocks.py
+++ b/app/stocks.py
@@ -1,0 +1,17 @@
+import yfinance as yf
+from typing import List, Dict
+
+
+def fetch_undervalued_stocks(tickers: List[str]) -> List[Dict[str, float]]:
+    """Fetch a list of undervalued stocks based on P/E ratio."""
+    results = []
+    for ticker in tickers:
+        try:
+            info = yf.Ticker(ticker).info
+            pe = info.get("trailingPE")
+            if pe is not None and pe < 15:
+                results.append({"symbol": ticker, "pe_ratio": pe})
+        except Exception:
+            # Ignore network or data errors and continue
+            continue
+    return sorted(results, key=lambda x: x["pe_ratio"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+apscheduler
+yfinance
+pandas


### PR DESCRIPTION
## Summary
- add a small FastAPI project
- provide scheduler-driven stock updates using yfinance
- document how to run the service

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e634caa2c8331b000d185a8f82dcc